### PR TITLE
0 padding added to .not-visible-message

### DIFF
--- a/css/small-business.css
+++ b/css/small-business.css
@@ -150,6 +150,7 @@ margin-top: 50px;
   .not-visible-message{
     height:0px;
     opacity: 0;
+    padding: 0px;
   }
 
  .progress-indicator>li.completed .bubble {


### PR DESCRIPTION
The padding of that element was making it unable to click on the name field in the contact us page.